### PR TITLE
wine-crossover: Use muniversal.arch_compiler yes

### DIFF
--- a/emulators/wine-crossover/Portfile
+++ b/emulators/wine-crossover/Portfile
@@ -232,7 +232,7 @@ triplet.add_build           cross
 # https://gitlab.winehq.org/wine/wine/-/commit/b1f59bc679a8c2dea18a6789a5b9b1a1ae825129
 compiler.limit_flags        yes
 muniversal.arch_flag        no
-muniversal.arch_compiler    no
+muniversal.arch_compiler    yes
 configure.ldflags-delete    -L${compiler.library_path}
 configure.optflags          -g -O2
 
@@ -247,10 +247,10 @@ if {${os.major} > 18} {
 
     patchfiles-append       1001-remove-cross_compiling-check.diff
 
-    configure.cc            "/usr/bin/env arch -x86_64 ${prefix}/libexec/cx-llvm/bin/clang"
-    configure.cxx           "/usr/bin/env arch -x86_64 ${prefix}/libexec/cx-llvm/bin/clang++"
+    configure.cc            ${prefix}/libexec/cx-llvm/bin/clang
+    configure.cxx           ${prefix}/libexec/cx-llvm/bin/clang++
+    configure.cmd           ${worksrcpath}/configure
     configure.compiler.add_deps no
-    configure.cmd ${worksrcpath}/configure
 
     configure.args-append \
         --disable-winedbg


### PR DESCRIPTION
Need to verify this doesn’t cause problems for `-mwine32` target but I’d assume that shouldn’t be the case. Doig this if it works would be much cleaner and also get `wine-crossover` in-line with the other wine-* Portfiles.