### PR TITLE
Update crossovertricks to work without MacPorts

### DIFF
--- a/emulators/crossovertricks/files/crossovertricks
+++ b/emulators/crossovertricks/files/crossovertricks
@@ -20,10 +20,15 @@
 #
 
 export CX_INSTALL="@@APPLICATIONS@@/CrossOver-@@CX_VERSION@@.app"
+
+if [ ! -d "${CX_INSTALL}" ]; then
+    export CX_INSTALL="/Applications/CrossOver.app"
+fi
+
 export CX_WINEPATH="${CX_INSTALL}/Contents/SharedSupport/CrossOver/bin"
 export CX_BOTTLE="${CX_BOTTLE:-$HOME/Library/Application Support/CrossOver/Bottles/default}"
 
-if [ ! -d "${CX_BOTTLE}" ]; then
+if [ ! -d "${CX_BOTTLE_PATH}/${CX_BOTTLE}" ]; then
     echo "Please set \$CX_BOTTLE env to your CrossOver Bottle"; exit
 fi
 
@@ -31,6 +36,11 @@ export WINE="$CX_WINEPATH/wine"
 export WINE64="$CX_WINEPATH/wine"
 export WINEPREFIX="${CX_BOTTLE}"
 export WINETRICKS_WINE_VERSION=@@WINE_VERSION@@
+
+if [ "${WINETRICKS_WINE_VERSION}" == "@@WINE_VERSION@@" ]; then
+    read WINETRICKS_WINE_VERSION <<< $(wine --version | awk '/Public Version: / { print $3 }')
+fi
+
 export WINEDEBUG=-all
 
 exec winetricks "${@}"

--- a/emulators/crossovertricks/files/crossovertricks
+++ b/emulators/crossovertricks/files/crossovertricks
@@ -38,7 +38,7 @@ export WINEPREFIX="${CX_BOTTLE}"
 export WINETRICKS_WINE_VERSION=@@WINE_VERSION@@
 
 if [ "${WINETRICKS_WINE_VERSION}" == "@@WINE_VERSION@@" ]; then
-    read WINETRICKS_WINE_VERSION <<< $(wine --version | awk '/Public Version: / { print $3 }')
+    read WINETRICKS_WINE_VERSION <<< $(sed -n '2p' $CX_WINEPATH/../share/wine/wine.inf | tr ' ' '\a' | awk -F'\a' '{print $4}')
 fi
 
 export WINEDEBUG=-all

--- a/emulators/crossovertricks/files/crossovertricks
+++ b/emulators/crossovertricks/files/crossovertricks
@@ -38,7 +38,7 @@ export WINEPREFIX="${CX_BOTTLE}"
 export WINETRICKS_WINE_VERSION=@@WINE_VERSION@@
 
 if [ "${WINETRICKS_WINE_VERSION}" == "@@WINE_VERSION@@" ]; then
-    read WINETRICKS_WINE_VERSION <<< $(sed -n '2p' $CX_WINEPATH/../share/wine/wine.inf | tr ' ' '\a' | awk -F'\a' '{print $4}')
+    read WINETRICKS_WINE_VERSION <<< $(sed -n '2p' "$CX_WINEPATH/../share/wine/wine.inf" | tr ' ' '\a' | awk -F'\a' '{print $4}')
 fi
 
 export WINEDEBUG=-all


### PR DESCRIPTION
It would be great if crossovertricks also be available as a Homebrew formulae, as Homebrew users reports compatibility issues between Macports and Homebrew as can be seen [here](https://superuser.com/questions/181337/is-it-safe-to-install-both-homebrew-and-macports-on-the-same-machine).