### PR TITLE
Fix Error Message on non-ARM Macs

### DIFF
--- a/devel/d3dmetal/Portfile
+++ b/devel/d3dmetal/Portfile
@@ -72,7 +72,7 @@ notes "
 
 platform darwin i386 {
     try {
-        set is_rosetta2 [exec sysctl -n sysctl.proc_translated]
+        set is_rosetta2 [exec sysctl -in sysctl.proc_translated]
         if { ${is_rosetta2} != 1 } {
             ui_error "${name} requires an Apple Silicon mac"
             return -code error "unsupported platform"

--- a/devel/game-porting-toolkit/Portfile
+++ b/devel/game-porting-toolkit/Portfile
@@ -212,7 +212,7 @@ platform darwin arm {
 
 platform darwin i386 {
     try {
-        set is_rosetta2 [exec sysctl -n sysctl.proc_translated]
+        set is_rosetta2 [exec sysctl -in sysctl.proc_translated]
         if { ${is_rosetta2} != 1 } {
             ui_error "${name} requires an Apple Silicon mac"
             return -code error "unsupported platform"


### PR DESCRIPTION
The `devel/d3dmetal` and `devel/game-porting-toolkit` ports error during the portindex on a non-ARM Mac because `exec sysctl -n sysctl.proc_translated` fails with the error `sysctl: unknown oid 'sysctl.proc_translated'`

The solution is to also use the `-i` flag to ignore unknown OIDs.