### PR TITLE
wine-crossover: fix minor typo

### DIFF
--- a/emulators/wine-crossover/Portfile
+++ b/emulators/wine-crossover/Portfile
@@ -132,7 +132,7 @@ configure.args \
     --with-vulkan \
     --without-x
 
-configure.env.append        ac_cv_lib_soname_vulkan=
+configure.env-append        ac_cv_lib_soname_vulkan=
 
 # We need to tell the linker to add MacPorts & d3dmetal to the rpath stack.
 configure.ldflags-append    -Wl,-rpath,${compiler.library_path} -Wl,-rpath,${prefix}/libexec/d3dmetal/external


### PR DESCRIPTION
Currently the wine-crossover Portfile from this repo fails to parse with:
```
Failed to parse file emulators/wine-crossover/Portfile: invalid command name "configure.env.append"
```
The fix is simple:
`configure.env.append` -> `configure.env-append`