### PR TITLE
Add optional mouse input quirk workaround

### DIFF
--- a/emulators/wine-devel/Portfile
+++ b/emulators/wine-devel/Portfile
@@ -73,6 +73,9 @@ patchfiles-append \
 patchfiles-append \
     0003-winemac.drv-export-essential-apis.diff
 
+patchfiles-append \
+    0004-winemac.drv-tiny-cursor-clip.diff
+
 configure.checks.implicit_function_declaration.whitelist-append \
     __clear_cache \
     fallocate \

--- a/emulators/wine-devel/files/0004-winemac.drv-tiny-cursor-clip.diff
+++ b/emulators/wine-devel/files/0004-winemac.drv-tiny-cursor-clip.diff
@@ -1,0 +1,53 @@
+diff --git a/dlls/winemac.drv/macdrv_cocoa.h b/dlls/winemac.drv/macdrv_cocoa.h
+index 44614ae3e8a..bac618f2da6 100644
+--- a/dlls/winemac.drv/macdrv_cocoa.h
++++ b/dlls/winemac.drv/macdrv_cocoa.h
+@@ -158,6 +158,7 @@
+ extern int retina_enabled;  /* Whether Retina mode is enabled via registry setting. */
+ extern int retina_on;       /* Whether Retina mode is currently active (enabled and display is in default mode). */
+ extern int enable_app_nap;
++extern int tiny_cursor_clip;
+ 
+ static inline CGRect cgrect_mac_from_win(CGRect rect)
+ {
+diff --git a/dlls/winemac.drv/macdrv_main.c b/dlls/winemac.drv/macdrv_main.c
+index 923a6fc2ef5..5992c1661f1 100644
+--- a/dlls/winemac.drv/macdrv_main.c
++++ b/dlls/winemac.drv/macdrv_main.c
+@@ -60,6 +60,7 @@ int gl_surface_mode = GL_SURFACE_IN_FRONT_OPAQUE;
+ int retina_enabled = FALSE;
+ int enable_app_nap = FALSE;
+ BOOL force_backing_store = FALSE;
++int tiny_cursor_clip = FALSE;
+ 
+ UINT64 app_icon_callback = 0;
+ UINT64 app_quit_request_callback = 0;
+@@ -362,6 +363,9 @@ static void setup_options(void)
+     if (!get_config_key(hkey, appkey, "UsePreciseScrolling", buffer, sizeof(buffer)))
+         use_precise_scrolling = IS_OPTION_TRUE(buffer[0]);
+ 
++    if (!get_config_key(hkey, appkey, "TinyCursorClip", buffer, sizeof(buffer)))
++        tiny_cursor_clip = IS_OPTION_TRUE(buffer[0]);
++
+     if (!get_config_key(hkey, appkey, "OpenGLSurfaceMode", buffer, sizeof(buffer)))
+     {
+         static const WCHAR transparentW[] = {'t','r','a','n','s','p','a','r','e','n','t',0};
+diff --git a/dlls/winemac.drv/mouse.c b/dlls/winemac.drv/mouse.c
+index a87654e9885..2f910f1182e 100644
+--- a/dlls/winemac.drv/mouse.c
++++ b/dlls/winemac.drv/mouse.c
+@@ -669,8 +669,12 @@ BOOL macdrv_ClipCursor(const RECT *clip, BOOL reset)
+ 
+     if (clip)
+     {
+-        rect = CGRectMake(clip->left, clip->top, max(1, clip->right - clip->left),
+-                          max(1, clip->bottom - clip->top));
++        if (tiny_cursor_clip) {
++            rect = CGRectMake(max(1, (clip->right - clip->left) / 2), max(1, (clip->bottom - clip->top) / 2), 1, 1);
++        } else {
++            rect = CGRectMake(clip->left, clip->top, max(1, clip->right - clip->left),
++                              max(1, clip->bottom - clip->top));
++        }
+     }
+     else
+         rect = CGRectInfinite;


### PR DESCRIPTION
This was made to work around Warframe's mouse input, where it sets up ClipCursor properly, but mouse input is broken

dinput MouseWarpOverride force doesn't help with the game either because any mouse movement confuses the game on MacOS somehow, and dinput warp doesn't lock the cursor down

When enabled in registry, Warframe's ClipCursor call gets a new 1x1 rect in the original rect's center, locking the cursor down and allow proper mouse input